### PR TITLE
update LND connector with latest lnd.proto and GRPC handshake

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,6 +59,7 @@ typings/
 
 # lnd files
 lnd.cert
+tls.cert
 admin.macaroon
 
 # built files

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ You need to have `lnd.cert` and `admin.macaroon` files in project directory in o
 ### Start the server
 
 ```
-node index.js
+node server.js
 ```
 
 ## Credits

--- a/server/lightning/lnd.js
+++ b/server/lightning/lnd.js
@@ -5,25 +5,27 @@ const fs = require("fs");
 // expose the routes to our app with module.exports
 module.exports = function (protoPath, lndHost, lndCertPath, macaroonPath) {
 
-	process.env.GRPC_SSL_CIPHER_SUITES = "HIGH+ECDSA";
-
 	const lnrpcDescriptor = grpc.load(protoPath);
-
 	const lndCert = fs.readFileSync(lndCertPath);
 	const sslCreds = grpc.credentials.createSsl(lndCert);
+	const lnrpc = lnrpcDescriptor.lnrpc;
 
-	var credentials;
-	if (macaroonPath) {
-		var macaroonCreds = grpc.credentials.createFromMetadataGenerator(function (args, callback) {
-			const adminMacaroon = fs.readFileSync(macaroonPath);
-			const metadata = new grpc.Metadata();
-			metadata.add("macaroon", adminMacaroon.toString("hex"));
-			callback(null, metadata);
-		});
-		credentials = grpc.credentials.combineChannelCredentials(sslCreds, macaroonCreds);
-	} else {
-		credentials = sslCreds;
-	}
+	var macaroonCreds = grpc.credentials.createFromMetadataGenerator(function (args, callback) {
+	        const adminMacaroon = fs.readFileSync(macaroonPath);
+	        const metadata = new grpc.Metadata();
+	        metadata.add("macaroon", adminMacaroon.toString("hex"));
+	        callback(null, metadata);
+	});
+	credentials = grpc.credentials.combineChannelCredentials(sslCreds, macaroonCreds);
+
+	// test of rpc to lnd
+	var lightning = new lnrpc.Lightning('localhost:10009', credentials);
+	call = lightning.walletBalance({}, function(err, response) {
+	    console.log('WalletBalance error: ');
+            console.log(err);
+	    console.log('WalletBalance: ');
+	    console.log(response);
+	  })
 
 	return new lnrpcDescriptor.lnrpc.Lightning(lndHost, credentials);
 };

--- a/server/lnd.proto
+++ b/server/lnd.proto
@@ -251,7 +251,7 @@ service Lightning {
     */
     rpc CloseChannel (CloseChannelRequest) returns (stream CloseStatusUpdate) {
         option (google.api.http) = {
-            delete: "/v1/channels/{channel_point.funding_txid}/{channel_point.output_index}"
+            delete: "/v1/channels/{channel_point.funding_txid_str}/{channel_point.output_index}"
         };
     }
 
@@ -294,18 +294,18 @@ service Lightning {
     */
     rpc ListInvoices (ListInvoiceRequest) returns (ListInvoiceResponse) {
         option (google.api.http) = {
-            get: "/v1/invoices/{pending_only}"
+            get: "/v1/invoices"
         };
     }
 
     /** lncli: `lookupinvoice`
-    LookupInvoice attemps to look up an invoice according to its payment hash.
+    LookupInvoice attempts to look up an invoice according to its payment hash.
     The passed payment hash *must* be exactly 32 bytes, if not, an error is
     returned.
     */
     rpc LookupInvoice (PaymentHash) returns (Invoice) {
         option (google.api.http) = {
-            get: "/v1/invoices/{r_hash_str}"
+            get: "/v1/invoice/{r_hash_str}"
         };
     }
 
@@ -389,7 +389,7 @@ service Lightning {
     route to a target destination capable of carrying a specific amount of
     satoshis. The retuned route contains the full details required to craft and
     send an HTLC, also including the necessary information that should be
-    present within the Sphinx packet encapsualted within the HTLC.
+    present within the Sphinx packet encapsulated within the HTLC.
     */
     rpc QueryRoutes(QueryRoutesRequest) returns (QueryRoutesResponse) {
         option (google.api.http) = {
@@ -423,11 +423,6 @@ service Lightning {
     */
     rpc SubscribeChannelGraph(GraphTopologySubscription) returns (stream GraphTopologyUpdate);
 
-    /**
-    SetAlias sets the alias for this node; e.g. "alice"
-    */
-    rpc SetAlias(SetAliasRequest) returns (SetAliasResponse);
-
     /** lncli: `debuglevel`
     DebugLevel allows a caller to programmatically set the logging verbosity of
     lnd. The logging can be targeted according to a coarse daemon-wide logging
@@ -446,13 +441,13 @@ service Lightning {
         };
     }
 
-    /** lncli: `updatefees`
-    UpdateFees allows the caller to update the fee schedule for all channels
-    globally, or a particular channel.
+    /** lncli: `updatechanpolicy`
+    UpdateChannelPolicy allows the caller to update the fee schedule and
+    channel policies for all channels globally, or a particular channel.
     */
-    rpc UpdateFees(FeeUpdateRequest) returns (FeeUpdateResponse) {
+    rpc UpdateChannelPolicy(PolicyUpdateRequest) returns (PolicyUpdateResponse) {
         option (google.api.http) = {
-            post: "/v1/fees"
+            post: "/v1/chanpolicy"
             body: "*"
         };
     }
@@ -512,6 +507,9 @@ message SendRequest {
     payment to the recipient.
     */
     string payment_request = 6;
+
+    /// The CLTV delta from the current height that should be used to set the timelock for the final hop.
+    int32 final_cltv_delta = 7;
 }
 message SendResponse {
     string payment_error = 1 [json_name = "payment_error"];
@@ -520,16 +518,16 @@ message SendResponse {
 }
 
 message ChannelPoint {
-    // TODO(roasbeef): make str vs bytes into a oneof
+    oneof funding_txid {
+        /// Txid of the funding transaction
+        bytes funding_txid_bytes = 1 [json_name = "funding_txid_bytes"];
 
-    /// Txid of the funding transaction
-    bytes funding_txid = 1 [ json_name = "funding_txid" ];
-
-    /// Hex-encoded string representing the funding transaction
-    string funding_txid_str = 2 [ json_name = "funding_txid_str" ];
+        /// Hex-encoded string representing the funding transaction
+        string funding_txid_str = 2 [json_name = "funding_txid_str"];
+    }
 
     /// The index of the output of the funding transaction
-    uint32 output_index = 3 [ json_name = "output_index" ];
+    uint32 output_index = 3 [json_name = "output_index"];
 }
 
 message LightningAddress {
@@ -612,7 +610,7 @@ message VerifyMessageRequest {
     /// The message over which the signature is to be verified
     bytes msg = 1 [ json_name = "msg" ];
 
-    /// The signature to be verifed over the given message
+    /// The signature to be verified over the given message
     string signature = 2 [ json_name = "signature" ];
 }
 message VerifyMessageResponse {
@@ -842,8 +840,9 @@ message CloseChannelRequest {
     int32 target_conf = 3;
 
     /// A manual fee rate set in sat/byte that should be used when crafting the closure transaction.
-    int64 sat_per_byte = 5;
+    int64 sat_per_byte = 4;
 }
+
 message CloseStatusUpdate {
     oneof update {
         PendingUpdate close_pending = 1 [json_name = "close_pending"];
@@ -865,7 +864,7 @@ message OpenChannelRequest {
     /// The pubkey of the node to open a channel with
     bytes node_pubkey = 2 [json_name = "node_pubkey"];
 
-    /// The hex encorded pubkey of the node to open a channel with 
+    /// The hex encoded pubkey of the node to open a channel with 
     string node_pubkey_string = 3 [json_name = "node_pubkey_string"];
 
     /// The number of satoshis the wallet should commit to the channel
@@ -882,6 +881,9 @@ message OpenChannelRequest {
 
     /// Whether this channel should be private, not announced to the greater network.
     bool private = 8 [json_name = "private"];
+
+    /// The minimum value in millisatoshi we will require for incoming HTLCs on the channel.
+    int64 min_htlc_msat = 9 [json_name = "min_htlc_msat"];
 }
 message OpenStatusUpdate {
     oneof update {
@@ -1030,6 +1032,9 @@ message QueryRoutesRequest {
 
     /// The amount to send expressed in satoshis
     int64 amt = 2;
+
+    /// The max number of routes to return.
+    int32 num_routes = 3;
 }
 message QueryRoutesResponse {
     repeated Route routes = 1 [ json_name = "routes"];
@@ -1245,12 +1250,6 @@ message ClosedChannelUpdate {
     ChannelPoint chan_point = 4;
 }
 
-message SetAliasRequest {
-    string new_alias = 1;
-}
-message SetAliasResponse {
-}
-
 message Invoice {
     /**
     An optional memo to attach along with the invoice. Used for record keeping
@@ -1342,6 +1341,7 @@ message InvoiceSubscription {
 message Payment {
     /// The payment hash
     string payment_hash = 1 [json_name = "payment_hash"];
+
     /// The value of the payment in satoshis
     int64 value = 2 [json_name = "value"];
 
@@ -1353,6 +1353,9 @@ message Payment {
 
     /// The fee paid for this payment in satoshis
     int64 fee = 5 [json_name = "fee"];
+
+    /// The payment preimage
+    string payment_preimage = 6 [json_name = "payment_preimage"];
 }
 
 message ListPaymentsRequest {
@@ -1412,12 +1415,12 @@ message FeeReportResponse {
     repeated ChannelFeeReport channel_fees = 1 [json_name = "channel_fees"];
 }
 
-message FeeUpdateRequest {
+message PolicyUpdateRequest {
     oneof scope {
-        /// If set, then this fee update applies to all currently active channels.
+        /// If set, then this update applies to all currently active channels.
         bool global = 1 [json_name = "global"] ;
 
-        /// If set, this fee update will target a specific channel.
+        /// If set, this update will target a specific channel.
         ChannelPoint chan_point = 2 [json_name = "chan_point"];
     }
 
@@ -1426,6 +1429,9 @@ message FeeUpdateRequest {
 
     /// The effective fee rate in milli-satoshis. The precision of this value goes up to 6 decimal places, so 1e-6.
     double fee_rate = 4 [json_name = "fee_rate"];
+
+    /// The required timelock delta for HTLCs forwarded over the channel.
+    uint32 time_lock_delta = 5 [json_name = "time_lock_delta"];
 }
-message FeeUpdateResponse {
+message PolicyUpdateResponse {
 }

--- a/server/main.js
+++ b/server/main.js
@@ -22,7 +22,7 @@ module.exports = function (app, options) {
             dir = __dirname;
         }
         const protoPath = path.join(dir, 'lnd.proto');
-        const lndCertPath = path.join(dir, 'lnd.cert');
+        const lndCertPath = path.join(dir, 'tls.cert');
         const macaroonPath = path.join(dir, 'admin.macaroon');
         const lnd = require("./lightning/lnd")(protoPath, lndHost, lndCertPath, macaroonPath);
         lightning = lnd;


### PR DESCRIPTION
There were changes in LND credentials / macaroon system which broke the
old way of connecting LDN GRPC server. The server would log the failue like this:

    ssl_transport_security.cc:976] Handshake failed with fatal error SSL_ERROR_SSL: error:14094410:SSL routines:ssl3_read_bytes:sslv3 alert handshake failure.

This change makes recksplorer
work with the latest LND version: lightningnetwork/lnd@7abdd30a878efb3673ce4dfe0070570a6c9444c8